### PR TITLE
Ability to override the binary paths

### DIFF
--- a/ch-kubectl
+++ b/ch-kubectl
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## Var env using in the script
-KUBECTL_BINS="${HOME}/.bin/kubectl_bins"
-KUBECTL_BIN_PATH="${HOME}/.bin/kubectl"
+KUBECTL_BINS="${KUBECTL_BINS:-${HOME}/.bin/kubectl_bins}"
+KUBECTL_BIN_PATH="${KUBECTL_BINS:-${HOME}/.bin/kubectl}"
 
 ## Selected kubectl version
 SELECTED_VERSION_FILE_NAME=".selected_version"

--- a/ch-kubectl
+++ b/ch-kubectl
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## Var env using in the script
 KUBECTL_BINS="${KUBECTL_BINS:-${HOME}/.bin/kubectl_bins}"
-KUBECTL_BIN_PATH="${KUBECTL_BINS:-${HOME}/.bin/kubectl}"
+KUBECTL_BIN_PATH="${KUBECTL_BIN_PATH:-${HOME}/.bin/kubectl}"
 
 ## Selected kubectl version
 SELECTED_VERSION_FILE_NAME=".selected_version"


### PR DESCRIPTION
Thank you for this tool! It's really useful for me. However, I didn't want my binaries in `.bin/` so I made the environment variable configurable from outside. So users may export `KUBECTL_BIN_PATH` in their shell to be pointed to the right place and the script will use it. 